### PR TITLE
Add LayerNorm support

### DIFF
--- a/onnx2pytorch/convert/attribute.py
+++ b/onnx2pytorch/convert/attribute.py
@@ -79,6 +79,8 @@ def extract_attributes(node):
                 )
         elif attr.name == "axis" and node.op_type == "Flatten":
             kwargs["start_dim"] = extract_attr_values(attr)
+        elif attr.name == "axis" and node.op_type == "LayerNormalization":
+            kwargs["axis"] = extract_attr_values(attr)
         elif attr.name == "axis" or attr.name == "axes":
             v = extract_attr_values(attr)
             if isinstance(v, (tuple, list)) and len(v) == 1:

--- a/onnx2pytorch/convert/operations.py
+++ b/onnx2pytorch/convert/operations.py
@@ -137,6 +137,8 @@ def convert_operations(onnx_graph, opset_version, batch_dim=0, enable_pruning=Tr
             op = nn.Identity()
         elif node.op_type == "InstanceNormalization":
             op = convert_instance_norm_layer(node, params=params)
+        elif node.op_type == "LayerNormalization":
+            op = LayerNorm(**extract_attributes(node))
         elif node.op_type == "LeakyRelu":
             op = nn.LeakyReLU(**extract_attributes(node), inplace=True)
         elif node.op_type == "Less":

--- a/onnx2pytorch/operations/__init__.py
+++ b/onnx2pytorch/operations/__init__.py
@@ -13,6 +13,7 @@ from .gathernd import GatherND
 from .globalaveragepool import GlobalAveragePool
 from .hardsigmoid import Hardsigmoid
 from .instancenorm import InstanceNormWrapper
+from .layernorm import LayerNorm
 from .loop import Loop
 from .lstm import LSTMWrapper
 from .matmul import MatMul
@@ -55,6 +56,7 @@ __all__ = [
     "GatherND",
     "GlobalAveragePool",
     "InstanceNormWrapper",
+    "LayerNorm",
     "Loop",
     "LSTMWrapper",
     "MatMul",

--- a/onnx2pytorch/operations/layernorm.py
+++ b/onnx2pytorch/operations/layernorm.py
@@ -1,0 +1,25 @@
+import torch
+from torch import nn
+from typing import Optional
+
+
+class LayerNorm(nn.Module):  # pylint: disable=missing-docstring
+    def __init__(self, axis: int, eps: float):
+        super().__init__()
+        self.axis = axis
+        self.eps = eps
+
+    def forward(  # pylint: disable=missing-function-docstring
+        self,
+        inputs: torch.Tensor,
+        scale: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        normalized_shape = inputs.shape[self.axis :]
+        return nn.functional.layer_norm(
+            input=inputs,
+            normalized_shape=normalized_shape,
+            weight=scale,
+            bias=bias,
+            eps=self.eps,
+        )


### PR DESCRIPTION
### Issue
Failed to convert ONNX model with `LayerNormalization` layer (`opset>=17`):
```
File "onnx2pytorch/onnx2pytorch/convert/operations.py", line 287, in convert_operations
    raise NotImplementedError(
NotImplementedError: Conversion not implemented for op_type=LayerNormalization.
```

### How to repro
Run:
```python
# 1. Export simple ONNX model with LayerNorm
import torch
from torch import nn
block = nn.LayerNorm([128])
input_tensor = torch.randn(1, 32, 128, 128)
onnx_path = "model_ln.onnx"
torch.onnx.export(
    block,
    input_tensor,
    onnx_path,
    input_names=['input'],
    output_names=['output'],
    opset_version=17
)

# 2. Convert ONNX model back to PyTorch
import onnx
import onnx2pytorch
onnx_model = onnx.load(onnx_path)
pytorch_model = onnx2pytorch.ConvertModel(onnx_model)  # -> Error occurs here

# 3. Recover ONNX model and check they're the same
torch.onnx.export(
    pytorch_model,
    input_tensor,
    onnx_path.replace(".onnx", "_recovered.onnx"),
    input_names=['input'],
    output_names=['output'],
    opset_version=17
)
```