### PR TITLE
patch reduce_max and ConvertModel.forward retention of output activations

### DIFF
--- a/onnx2pytorch/convert/model.py
+++ b/onnx2pytorch/convert/model.py
@@ -220,7 +220,8 @@ class ConvertModel(nn.Module):
                 if in_op_id in still_needed_by:
                     still_needed_by[in_op_id].discard(out_op_id)
                     if len(still_needed_by[in_op_id]) == 0:
-                        if in_op_id in activations:
+                        # only delete the activation of this layer if it is not an output
+                        if in_op_id not in self.output_names:
                             del activations[in_op_id]
 
             if self.debug:

--- a/onnx2pytorch/convert/model.py
+++ b/onnx2pytorch/convert/model.py
@@ -220,9 +220,10 @@ class ConvertModel(nn.Module):
                 if in_op_id in still_needed_by:
                     still_needed_by[in_op_id].discard(out_op_id)
                     if len(still_needed_by[in_op_id]) == 0:
-                        # only delete the activation of this layer if it is not an output
-                        if in_op_id not in self.output_names:
-                            del activations[in_op_id]
+                        if in_op_id in activations:
+                            # only delete the activation of this layer if it is not an output
+                            if in_op_id not in self.output_names:
+                                del activations[in_op_id]
 
             if self.debug:
                 # compare if the activations of pytorch are the same as from onnxruntime

--- a/onnx2pytorch/convert/operations.py
+++ b/onnx2pytorch/convert/operations.py
@@ -217,7 +217,7 @@ def convert_operations(onnx_graph, opset_version, batch_dim=0, enable_pruning=Tr
         elif node.op_type == "Reciprocal":
             op = OperatorWrapper(torch.reciprocal)
         elif node.op_type == "ReduceMax":
-            op = ReduceMax(**extract_attributes(node))
+            op = ReduceMax(opset_version=opset_version, **extract_attributes(node))
         elif node.op_type == "ReduceMean":
             kwargs = dict(keepdim=True)
             kwargs.update(extract_attributes(node))

--- a/onnx2pytorch/operations/reducemax.py
+++ b/onnx2pytorch/operations/reducemax.py
@@ -3,13 +3,26 @@ from torch import nn
 
 
 class ReduceMax(nn.Module):
-    def __init__(self, dim=None, keepdim=True):
+    def __init__(
+        self, opset_version, dim=None, keepdim=True, noop_with_empty_axes=False
+    ):
+        self.opset_version = opset_version
         self.dim = dim
         self.keepdim = keepdim
+        self.noop_with_empty_axes = noop_with_empty_axes
         super().__init__()
 
-    def forward(self, data: torch.Tensor):
-        dim = self.dim
-        if dim is None:
-            dim = tuple(range(data.ndim))
-        return torch.amax(data, dim=dim, keepdim=self.keepdim)
+    def forward(self, data: torch.Tensor, axes: torch.Tensor = None):
+        if self.opset_version < 13:
+            dims = self.dim
+        else:
+            dims = axes
+        if dims is None:
+            if self.noop_with_empty_axes:
+                return data
+            else:
+                dims = tuple(range(data.ndim))
+        if isinstance(dims, int):
+            return torch.amax(data, dim=dims, keepdim=self.keepdim)
+        else:
+            return torch.amax(data, dim=tuple(list(dims)), keepdim=self.keepdim)

--- a/tests/onnx2pytorch/operations/test_reducemax.py
+++ b/tests/onnx2pytorch/operations/test_reducemax.py
@@ -10,7 +10,7 @@ def tensor():
 
 
 def test_reduce_max_with_dim(tensor):
-    reduce_max = ReduceMax(dim=0, keepdim=True)
+    reduce_max = ReduceMax(opset_version=13, dim=0, keepdim=True)
     output = reduce_max(tensor)
     expected_output = torch.tensor([[7, 8, 9]])
 
@@ -19,7 +19,7 @@ def test_reduce_max_with_dim(tensor):
 
 
 def test_reduce_max(tensor):
-    reduce_max = ReduceMax(keepdim=False)
+    reduce_max = ReduceMax(opset_version=13, keepdim=False)
     output = reduce_max(tensor)
     expected_output = torch.tensor(9)
 


### PR DESCRIPTION
These were small patches that I needed to implement in order to convert an onnx model (link below) to PyTorch, as mentioned in #78 
onnx model: https://huggingface.co/justinchuby/Perch-onnx/blob/main/perch_v2_no_dft.onnx

For what it's worth, I also had to modify the Pad and Reshape ConvertModel layers to avoid incorrect padding and reshaping behavior. I don't know if there is a generalizable fix to these issues. 

```python
# patches to fix ONNX → PyTorch conversion issues
class FixedONNXPad(nn.Module):  # patchs onnx2pytorch's pad.Pad
    def forward(self, input, pads=None, value=0):
        if pads is None:
            raise TypeError("pads must be provided")

        pads = pads.tolist() if torch.is_tensor(pads) else list(pads)

        ndim = input.ndim
        assert len(pads) == 2 * ndim, (pads, input.shape)

        before = pads[:ndim]
        after = pads[ndim:]

        # Convert ONNX → PyTorch pad order
        torch_pads = []
        for b, a in zip(reversed(before), reversed(after)):
            torch_pads.extend([b, a])

        return F.pad(input, torch_pads, value=value)


class FixedReshape(nn.Module):
    def forward(self, x, shape=None):
        B, H, Q, D = x.shape
        assert D % 4 == 0
        return x.view(B, H, Q, D // 4, 4)
    
onnx_model = onnx.load("./perch_v2_no_dft.onnx") 
pytorch_model = ConvertModel(onnx_model)
pytorch_model.Pad_pad_output_0 = FixedONNXPad()
pytorch_model._modules[
    "Reshape_jit(infer_fn)/MultiHeadClassifier/MultiHeadClassifier._call_model/heads_protopnet_logits/dot_general10_reshaped_0"
] = FixedReshape()
```